### PR TITLE
Change autoOpen to autoDisplay in docs for Modal's options

### DIFF
--- a/dist/js/ink.modal.js
+++ b/dist/js/ink.modal.js
@@ -276,7 +276,7 @@ Ink.createModule('Ink.UI.Modal', '1', ['Ink.UI.Common_1','Ink.Dom.Event_1','Ink.
 
         /**
          * Opens this Modal. 
-         * Use this if you created the modal with `autoOpen: false`
+         * Use this if you created the modal with `autoDisplay: false`
          * to open the modal when you want to.
          * @method open 
          * @param {Event} [event] (internal) In case its fired by the internal trigger.

--- a/src/js/Ink/UI/Modal/1/lib.js
+++ b/src/js/Ink/UI/Modal/1/lib.js
@@ -276,7 +276,7 @@ Ink.createModule('Ink.UI.Modal', '1', ['Ink.UI.Common_1','Ink.Dom.Event_1','Ink.
 
         /**
          * Opens this Modal. 
-         * Use this if you created the modal with `autoOpen: false`
+         * Use this if you created the modal with `autoDisplay: false`
          * to open the modal when you want to.
          * @method open 
          * @param {Event} [event] (internal) In case its fired by the internal trigger.

--- a/test/unit/Ink.UI.Modal_1/test.js
+++ b/test/unit/Ink.UI.Modal_1/test.js
@@ -34,7 +34,7 @@ Ink.requireModules(['Ink.UI.Modal_1', 'Ink.Dom.Element_1', 'Ink.Dom.Css_1'], fun
         }, { trigger: trigger })
     }(InkElement.create('a', { href: '#' })));
 
-    modalTest('Neither does it open if you set autoOpen:false as an option', function(modal, els) {
+    modalTest('Neither does it open if you set autoDisplay:false as an option', function(modal, els) {
         ok(!modal.isOpen(), 'Modal is closed');
     }, { autoDisplay: false });
 


### PR DESCRIPTION
The documentation for Modal's options incorrectly references an "autoOpen" option when it's really "autoDisplay." This PR corrects that mistake.