### PR TITLE
Unstyled list inside an unstyled list

### DIFF
--- a/src/sass/modules/_typography.scss
+++ b/src/sass/modules/_typography.scss
@@ -144,6 +144,7 @@ ul, ol {
     }
 }
 
+
 ul {
 
     &.unstyled {
@@ -152,6 +153,10 @@ ul {
 
         ul  {
             list-style:disc outside;
+            &.unstyled {
+                list-style: none;
+                padding-left: 0em;
+            }
         }
     }
 
@@ -167,6 +172,8 @@ ul {
         }
     }
 }
+
+
 
 dl {
     margin: 1em 0;


### PR DESCRIPTION
Add an exception to the previous setting which was making the second
list styled.
So, for the previous setting to work, one only needs to remove the
class “unstyled” from the ul wanted to be styled.