### PR TITLE
also bundle css

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -9,7 +9,8 @@
     "SASS"
   ],
   "main": [
-    "dist/js/ink-all.js"
+    "dist/js/ink-all.js",
+    "dist/css/ink.css"
   ],
   "ignore": [
     "**/.*",


### PR DESCRIPTION
When using rails-assets, css file location cannot be automatically detected. This change is intended to fix this.