### PR TITLE
Fix wrong font-weight for class '.condensed-300'

### DIFF
--- a/src/sass/modules/_typography.scss
+++ b/src/sass/modules/_typography.scss
@@ -16,7 +16,7 @@ body {
 .fw-700, .fw-bold { font-weight: 700; }
 .fw-900, .fw-black { font-weight: 900; }
 
-.condensed-300, .condensed-thin { font-weight: 200; font-family: $condensed-font-stack; }
+.condensed-300, .condensed-thin { font-weight: 300; font-family: $condensed-font-stack; }
 .condensed-400, .condensed-regular { font-weight: 400; font-family: $condensed-font-stack; }
 .condensed-700, .condensed-bold { font-weight: 700; font-family: $condensed-font-stack; }
 


### PR DESCRIPTION
The font-weight value is 200 instead of 300.
Fixes #439 