### PR TITLE
Duplicated ':hover' in some rules of dropdown

### DIFF
--- a/src/sass/modules/_nav.dropdown.scss
+++ b/src/sass/modules/_nav.dropdown.scss
@@ -115,10 +115,8 @@
                         
                     }
 
-                    &:hover {
-                        > ul.dropdown-menu, > ul.dropdown {
-                            display: block;
-                        }
+                    > ul.dropdown-menu, > ul.dropdown {
+                        display: block;
                     }
 
                 }


### PR DESCRIPTION
Fix duplication of ':hover' selector on some rules of dropdown due to a repetition of a parent selector.
It results in '... li.submenu:hover:hover ...'