### PR TITLE
Fix invalid CSS rules in JS modules

### DIFF
--- a/src/sass/modules/js/_progressbar.scss
+++ b/src/sass/modules/js/_progressbar.scss
@@ -5,7 +5,7 @@
     background: $progress-bar-bg;
     position: relative;
     @include border-radius($border-radius);  
-    @include box-shadow(0, 1px, 3px, 0, rgba( 0, 0, 0, 0.2), inset);
+    @include box-shadow(inset 0 1px 3px 0 rgba( 0, 0, 0, 0.2));
 
     .caption {
         position: absolute;
@@ -22,8 +22,8 @@
     
     .bar {
         height: 1.3em;
-        @include text-shadow (rgba(0, 0, 0, 0.25), 0, 1px, 0);
-        @include  box-shadow(0, 1px, 1px, 0, rgba(0, 0, 0, 0.1), inset);
+        @include text-shadow (0 1px 0 rgba(0, 0, 0, 0.25));
+        @include box-shadow(inset 0 1px 1px 0 rgba(0, 0, 0, 0.1));
 
         @include transition-property(width);
         @include transition-duration(0.6s);

--- a/src/sass/modules/js/_sortable.list.scss
+++ b/src/sass/modules/js/_sortable.list.scss
@@ -15,7 +15,7 @@
 }
 
 .drag {
-    @include box-shadow (0, 0px, 10px, 0, rgba( 0, 0, 0, 0.3));
+    @include box-shadow (0 0 10px 0 rgba(0, 0, 0, 0.3));
 }
 
 .#{$sortable-list-class-name} {

--- a/src/sass/modules/js/_tagfield.scss
+++ b/src/sass/modules/js/_tagfield.scss
@@ -11,7 +11,7 @@
 			@include border-radius(2px);
 
 			&:focus {
-				@include box-shadow(0px, 0px, 0px, 3px, #eaeaea);
+				@include box-shadow(0 0 0 3px #eaeaea);
 				border: 1px solid #c3c3c3;
 			}
 		}


### PR DESCRIPTION
The progress bar, sortable list and tag field output invalid
text-shadow and box-shadow properties.