### PR TITLE
Reduced specificity of table CSS rules + row hover in IE7

### DIFF
--- a/src/sass/modules/_tables.scss
+++ b/src/sass/modules/_tables.scss
@@ -5,31 +5,27 @@ table {
         width: 100%;
         border-collapse: collapse;
         border-spacing: 0;
-        
-        tr {
-            th {
-                padding: $table-cell-padding;
-                line-height: $table-row-line-height;
-                &[data-sortable="true"]{
-                
-                    &:hover {
-                        cursor: pointer;
-                        text-decoration: underline;
-                        i {
-                            text-decoration: none;
-                        }
-                    }
 
+        th, td {
+            padding: $table-cell-padding;
+            line-height: $table-row-line-height;
+        }
+
+        th {
+            &[data-sortable="true"]{
+
+                &:hover {
+                    cursor: pointer;
+                    text-decoration: underline;
                     i {
-                        padding-left: .5em;
+                        text-decoration: none;
                     }
-                    
                 }
-            }
 
-            td {
-                padding: $table-cell-padding;
-                line-height: $table-row-line-height;
+                i {
+                    padding-left: .5em;
+                }
+
             }
         }
 

--- a/src/sass/themes/_tables.scss
+++ b/src/sass/themes/_tables.scss
@@ -5,7 +5,6 @@ table.#{$table-class-name} {
     tr {
         th, td {
             border-bottom: $table-cell-borderColor 1px solid; 
-            background:none
         }
 
         &:last-child {


### PR DESCRIPTION
This pull request:
- reduce some specificity of the CSS rules in the ink-table module
- remove a little bit of redundancy
- fixes the hover of rows in IE7