### PR TITLE
Deprecation fixes in cookbook examples

### DIFF
--- a/dist/cookbook/3-boxes.html
+++ b/dist/cookbook/3-boxes.html
@@ -3,7 +3,7 @@
 
     <head>
         <meta charset="utf-8">
-        <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
+        <meta http-equiv="X-UA-Compatible" content="IE=edge">
         <title>3 Boxes</title>
         <meta name="description" content="">
         <meta name="author" content="ink, cookbook, recipes">

--- a/dist/cookbook/3-boxes.html
+++ b/dist/cookbook/3-boxes.html
@@ -72,7 +72,7 @@
 
         <div class="ink-grid">
 
-            <!--[if lte IE 9 ]>
+            <!--[if lt IE 9 ]>
             <div class="ink-alert basic" role="alert">
                 <button class="ink-dismiss">&times;</button>
                 <p>

--- a/dist/cookbook/4-boxes.html
+++ b/dist/cookbook/4-boxes.html
@@ -3,7 +3,7 @@
 
     <head>
         <meta charset="utf-8">
-        <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
+        <meta http-equiv="X-UA-Compatible" content="IE=edge">
         <title>4 Boxes</title>
         <meta name="description" content="">
         <meta name="author" content="ink, cookbook, recipes">

--- a/dist/cookbook/4-boxes.html
+++ b/dist/cookbook/4-boxes.html
@@ -68,7 +68,7 @@
 
         <div class="ink-grid">
 
-            <!--[if lte IE 9 ]>
+            <!--[if lt IE 9 ]>
             <div class="ink-alert basic" role="alert">
                 <button class="ink-dismiss">&times;</button>
                 <p><strong>You are using an outdated Internet Explorer version.</strong>

--- a/dist/cookbook/advanced-grid.html
+++ b/dist/cookbook/advanced-grid.html
@@ -3,7 +3,7 @@
 
     <head>
         <meta charset="utf-8">
-        <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
+        <meta http-equiv="X-UA-Compatible" content="IE=edge">
         <title>Advanced Grid</title>
         <meta name="description" content="">
         <meta name="author" content="ink, cookbook, recipes">

--- a/dist/cookbook/advanced-grid.html
+++ b/dist/cookbook/advanced-grid.html
@@ -67,7 +67,7 @@
 
         <div class="ink-grid">
 
-            <!--[if lte IE 9 ]>
+            <!--[if lt IE 9 ]>
             <div class="ink-alert basic" role="alert">
                 <button class="ink-dismiss">&times;</button>
                 <p>

--- a/dist/cookbook/article-page.html
+++ b/dist/cookbook/article-page.html
@@ -91,7 +91,7 @@
 
         <div class="ink-grid">
 
-            <!--[if lte IE 9 ]>
+            <!--[if lt IE 9 ]>
             <div class="ink-alert basic" role="alert">
                 <button class="ink-dismiss">&times;</button>
                 <p>

--- a/dist/cookbook/article-page.html
+++ b/dist/cookbook/article-page.html
@@ -3,7 +3,7 @@
 
     <head>
         <meta charset="utf-8">
-        <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
+        <meta http-equiv="X-UA-Compatible" content="IE=edge">
         <title>Article page</title>
         <meta name="description" content="">
         <meta name="author" content="ink, cookbook, recipes">

--- a/dist/cookbook/carousel.html
+++ b/dist/cookbook/carousel.html
@@ -69,7 +69,7 @@
 <div class="ink-grid vertical-space">
 
 
-    <!--[if lte IE 9 ]>
+    <!--[if lt IE 9 ]>
     <div class="ink-alert basic" role="alert">
         <button class="ink-dismiss">&times;</button>
         <p>

--- a/dist/cookbook/carousel.html
+++ b/dist/cookbook/carousel.html
@@ -3,7 +3,7 @@
 
     <head>
         <meta charset="utf-8">
-        <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
+        <meta http-equiv="X-UA-Compatible" content="IE=edge">
         <title>Carousel</title>
         <meta name="description" content="">
         <meta name="author" content="ink, cookbook, recipes">

--- a/dist/cookbook/fixed-width-column.html
+++ b/dist/cookbook/fixed-width-column.html
@@ -119,7 +119,7 @@
     <body>
         <div class="ink-grid">
 
-            <!--[if lte IE 9 ]>
+            <!--[if lt IE 9 ]>
             <div class="ink-alert basic" role="alert">
                 <button class="ink-dismiss">&times;</button>
                 <p>

--- a/dist/cookbook/fixed-width-column.html
+++ b/dist/cookbook/fixed-width-column.html
@@ -3,7 +3,7 @@
 
     <head>
         <meta charset="utf-8">
-        <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
+        <meta http-equiv="X-UA-Compatible" content="IE=edge">
         <title>Fixed width column</title>
         <meta name="description" content="">
         <meta name="author" content="ink, cookbook, recipes">

--- a/dist/cookbook/forms.html
+++ b/dist/cookbook/forms.html
@@ -74,7 +74,7 @@
     <body>
         <div class="ink-grid">
 
-            <!--[if lte IE 9 ]>
+            <!--[if lt IE 9 ]>
             <div class="ink-alert basic" role="alert">
                 <button class="ink-dismiss">&times;</button>
                 <p>

--- a/dist/cookbook/forms.html
+++ b/dist/cookbook/forms.html
@@ -3,7 +3,7 @@
 
     <head>
         <meta charset="utf-8">
-        <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
+        <meta http-equiv="X-UA-Compatible" content="IE=edge">
         <title>Forms</title>
         <meta name="description" content="">
         <meta name="author" content="ink, cookbook, recipes">

--- a/dist/cookbook/gallery-modal.html
+++ b/dist/cookbook/gallery-modal.html
@@ -3,7 +3,7 @@
 
     <head>
         <meta charset="utf-8">
-        <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
+        <meta http-equiv="X-UA-Compatible" content="IE=edge">
         <title>Modal gallery</title>
         <meta name="description" content="">
         <meta name="author" content="ink, cookbook, recipes">

--- a/dist/cookbook/quick-start.html
+++ b/dist/cookbook/quick-start.html
@@ -3,7 +3,7 @@
 
     <head>
         <meta charset="utf-8">
-        <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
+        <meta http-equiv="X-UA-Compatible" content="IE=edge">
         <title>Quick start</title>
         <meta name="description" content="">
         <meta name="author" content="ink, cookbook, recipes">

--- a/dist/cookbook/quick-start.html
+++ b/dist/cookbook/quick-start.html
@@ -105,7 +105,7 @@
 
     <body>
 
-        <!--[if lte IE 9 ]>
+        <!--[if lt IE 9 ]>
         <div class="ink-alert basic" role="alert">
             <button class="ink-dismiss">&times;</button>
             <p>

--- a/dist/cookbook/sticky-footer.html
+++ b/dist/cookbook/sticky-footer.html
@@ -77,7 +77,7 @@
 
     <body>
 
-        <!--[if lte IE 9 ]>
+        <!--[if lt IE 9 ]>
         <div class="ink-grid">
             <div class="ink-alert basic">
                 <button class="ink-dismiss">&times;</button>

--- a/dist/cookbook/sticky-footer.html
+++ b/dist/cookbook/sticky-footer.html
@@ -3,7 +3,7 @@
 
     <head>
         <meta charset="utf-8">
-        <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
+        <meta http-equiv="X-UA-Compatible" content="IE=edge">
         <title>Sticky footer</title>
         <meta name="description" content="">
         <meta name="author" content="ink, cookbook, recipes">


### PR DESCRIPTION
This pull request combine 2 changes:

1. Remove the meta reference for Google Chrome Frame
    * Chrome Frame has been unsupported for more than 1 year by now
    * None of the main framework/boilerplate player support GCF call
2. Fixes the unsupported browser warning to show only for IE<9
    * Since grid and media query behavior only starts to get affect for IE8 and older, the warning should reflect INK support.

