### PR TITLE
docs: Fix simple typo, depencies -> dependencies

### DIFF
--- a/src/js/Ink/Namespace/ClassModule/1/lib.js
+++ b/src/js/Ink/Namespace/ClassModule/1/lib.js
@@ -18,7 +18,7 @@ Ink.createModule(
     'Ink.Namespace.ClassModule',          // full module name
     '1',                                  // module's version
     ['Ink.Dom.Event_1', 'Ink.Dom.Css_1'], // array of dependency modules
-    function(Event, Css) {                // this fn will be called async with depencies as arguments
+    function(Event, Css) {                // this fn will be called async with dependencies as arguments
 
         'use strict';
 

--- a/src/js/Ink/Namespace/StaticModule/1/lib.js
+++ b/src/js/Ink/Namespace/StaticModule/1/lib.js
@@ -20,7 +20,7 @@ Ink.createModule(
     'Ink.Namespace.StaticModule',         // full module name
     '1',                                  // module's version
     ['Ink.Dom.Event_1', 'Ink.Dom.Css_1'], // array of dependency modules
-    function(Event, Css) {                // this fn will be called async with depencies as arguments
+    function(Event, Css) {                // this fn will be called async with dependencies as arguments
 
         'use strict';
 


### PR DESCRIPTION
There is a small typo in src/js/Ink/Namespace/ClassModule/1/lib.js, src/js/Ink/Namespace/StaticModule/1/lib.js.

Should read `dependencies` rather than `depencies`.

